### PR TITLE
Added GitHub action to automatically build PyTTa distribution package. If it succeeds, it is uploaded to PyPI

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,102 @@
+# Guidelines 
+
+If this pull request is accepted `.github/workflows/README.md` file can be deleted or edited accordingly.
+
+## Reasoning
+
+1. Currently the last version of PyTTa compiled to pip doesn't correspond
+to the best version on the GitHub repository. In order to keep PyPI
+aligned to GitHub repo and always updated the `build-publish-to-pypy.yml` GitHub action is suggested.  
+
+    Since the intended goal of this pull request is to maintain PyPI always updated, `setup.py` was changed accordingly,
+introducing some classifiers and using the main `README.md` file as the project description for PyPI.
+
+    The main `README.md` file was changed to show the relevant changes. All of them refers to `pip` .
+  
+2. When installing PyTTa with `pip install pytta` its dependencies aren't installed automatically
+because of the old `setup.py` from PyTTa-0.1.0b1, making the user installing them manually.
+Since the build workflow uses always the latest `setup.py`,
+when an user install PyTTa with `pip install pytta` every listed dependency should now be installed together with PyTTa.
+
+3. To maintain PyTTa PyPI repository as close as possible to the current development branch source code.
+
+## How to setup this workflow
+
+The repository maintainers MUST add a GitHub secret for PyPI at 
+ [https://github.com/PyTTAmaster/PyTTa/settings/secrets](https://github.com/PyTTAmaster/PyTTa/settings/secrets).
+
+According to `.github/workflows/build-publish-to-pypi.yml` file:
+
+* PyPI secret name MUST be:
+
+    `Name: pypi_password`
+    
+    And its value MUST be:
+    
+    `Value: API TOKEN for PyTTa from https://pypi.org/`
+    
+GitHub Secrets are stored encrypted.
+
+## How it works 
+
+This workflow affects **only** tagged commits with a tag that starts with letter `v`.
+
+If the pushed commit **is** tagged with a tag **starting** with `v`,
+the action triggered will try to build PyTTa distribution package using latest Python stable version.
+If the package builds successfully it will be automatically uploaded to PyPI.
+
+This encourages a continuous delivery workflow and allow users to always have the latest release by using 
+`$ pip install pytta`.
+
+### Tagged commits
+
+To keep things organized:
+
+`settings{'version': x.y.zbw}`
+
+from setup.py MUST have the same version name as the git tag name,
+so that releases are properly tagged with the correct
+release version.
+
+When using tagged commits annotated tags are recommended and encouraged but not mandatory.
+
+## Examples
+
+### For annotated tags:
+
+The following syntax is used:
+
+`$ git tag -a <tag-name> -m <tagging-message>`
+
+e.g.: for setup.py containing `settings{'version': '0.1.0b9'}`, the following syntax would be used:
+
+`$ git tag -a v0.1.0b9 -m "simple tagging message"`
+
+By default, the `git push` command doesn’t transfer tags to remote servers,
+so you will have to **explicitly** push tags to origin after you have created them. The following syntax is used:
+
+`$ git push origin <tag-name>`
+
+The complete workflow in this example would be:
+
+```
+...
+$ git commit -m "commit message"
+$ git tag -a v0.1.0b9 -m "simple tagging message"
+$ git push origin v0.1.0b9
+
+# Alternatively you can use
+# $ git push origin <branch> v0.1.0b9
+# if you want to push the tagged commit to other branch than the default branch
+```
+
+After pushing the tagged commit `build-publish-to-pypi.yml` will be triggered.
+
+### For lightweight tags:
+
+The following syntax is used:
+
+`$ git tag <tag-name>`
+
+The complete workflow would be the same as above but using the lightweight tag syntax
+in place of the annotated tag syntax.

--- a/.github/workflows/build-publish-to-pypi.yml
+++ b/.github/workflows/build-publish-to-pypi.yml
@@ -1,0 +1,44 @@
+# GitHub Action for building and publishing PyTTa distribution package to PyPI automatically.
+# Tagged commits with a tag starting with letter 'v' are published as releases to PyPI (https://pypi.org/).
+
+name: (If commit contains version tag) Build and publish PyTTa distribution package to PyPI
+
+on:
+
+  # Trigger this workflow on push
+  push:
+
+    # and for tags starting with v 
+    tags:
+      - 'v*'        # Push event to v0.0, v0.1, v0.2, ... , and so on  
+
+jobs:
+
+  build-n-publish:
+    name: Build and publish PyTTa distribution package to PyPI
+    runs-on: ubuntu-latest
+
+    steps:
+
+    # Checks-out PyTTa repository, so this workflow can access it
+    - uses: actions/checkout@v2
+
+    # Setup latest Python stable version
+    - name: Set up Python 3.x (latest stable version)
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.x
+
+    - name: Install and upgrade build dependencies 
+      run: |
+        python3 -m pip install --upgrade pip setuptools wheel
+
+    - name: Build a binary wheel and a source tarball for PyTTa distribution package
+      run: |
+        python3 setup.py sdist bdist_wheel
+
+    - name: Publish Pytta distribution package to PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_password }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 PyTTa - Python in Technical Acoustics
+Copyright (c) 2020 PyTTa - Python in Technical Acoustics
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -88,16 +88,16 @@ https://pytta.readthedocs.io/
 
 ### Installation
 
+To install the last version compiled to pip, which can be slightly behind of
+development branch, do:
+
+    >>> pip install pytta
+    
 If you want to check the most up to date beta version, please get the
 development branch source code, clone our repository to your local git, or
 even install it from pip, as follows:
 
     >>> pip install git+https://github.com/pyttamaster/pytta@development
-
-To install the last version compiled to pip, which at this point may not be
-the best version on the repository, do:
-
-    >>> pip install pytta
 
 ### Contributing as a user
 

--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,16 @@ Authors:
 
 from setuptools import setup
 
+with open("README.md", "r") as f:
+    long_description = f.read()
+
 settings = {
     'name': 'PyTTa',
     'version': '0.1.0b9',
     'description': 'Signal processing tools for acoustics and vibrations in ' +
         'python, development package.',
+    'long_description': long_description,
+    'long_description_content_type': 'text/markdown',
     'url': 'http://github.com/PyTTAmaster/PyTTa',
     'author': 'João Vitor Paes, Matheus Lazarin, Marcos Reis',
     'author_email': 'pytta@eac.ufsm.br',
@@ -24,6 +29,10 @@ settings = {
         'sounddevice', 'soundfile', 'h5py', 'numba'],
     'packages': ['pytta', 'pytta.classes', 'pytta.apps', 'pytta.utils'],
     'package_dir': {'classes': 'pytta'},
+    'classifiers': [
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent", ],
     # 'package_data': {'pytta': ['examples/*.py', 'examples/RIS/*.mat']}
 }
 


### PR DESCRIPTION
Currently PyTTa version from PyPI repository is too distant from the GitHub repo. This problem is addressed with a GitHub action. There is a full explanation at `.github/workflows/README.md`