### PR TITLE
Fix errors on plot methods to plot on google colab

### DIFF
--- a/pytta/_plot.py
+++ b/pytta/_plot.py
@@ -76,8 +76,13 @@ def time(sigObjs, xLabel, yLabel, yLim, xLim, title, decimalSep, timeUnit):
         matplotlib.figure.Figure object.
     """
     if decimalSep == ',':
-        locale.setlocale(locale.LC_NUMERIC, 'pt_BR.UTF-8')
-        plt.rcParams['axes.formatter.use_locale'] = True
+        try:
+            locale.setlocale(locale.LC_NUMERIC, 'pt_BR.UTF-8')
+            plt.rcParams['axes.formatter.use_locale'] = True
+        except:
+            locale.setlocale(locale.LC_NUMERIC, 'C')
+            plt.rcParams['axes.formatter.use_locale'] = False
+            print("Plotting error using ',', then was used '.' as decimal separator")
     elif decimalSep =='.':
         locale.setlocale(locale.LC_NUMERIC, 'C')
         plt.rcParams['axes.formatter.use_locale'] = False
@@ -228,8 +233,13 @@ def time_dB(sigObjs, xLabel, yLabel, yLim, xLim, title, decimalSep, timeUnit):
         matplotlib.figure.Figure object.
     """
     if decimalSep == ',':
-        locale.setlocale(locale.LC_NUMERIC, 'pt_BR.UTF-8')
-        plt.rcParams['axes.formatter.use_locale'] = True
+        try:
+            locale.setlocale(locale.LC_NUMERIC, 'pt_BR.UTF-8')
+            plt.rcParams['axes.formatter.use_locale'] = True
+        except:
+            locale.setlocale(locale.LC_NUMERIC, 'C')
+            plt.rcParams['axes.formatter.use_locale'] = False
+            print("Plotting error using ',', then was used '.' as decimal separator")
     elif decimalSep =='.':
         locale.setlocale(locale.LC_NUMERIC, 'C')
         plt.rcParams['axes.formatter.use_locale'] = False
@@ -386,8 +396,13 @@ def freq(sigObjs, smooth, xLabel, yLabel, yLim, xLim, title, decimalSep):
         matplotlib.figure.Figure object.
     """
     if decimalSep == ',':
-        locale.setlocale(locale.LC_NUMERIC, 'pt_BR.UTF-8')
-        plt.rcParams['axes.formatter.use_locale'] = True
+        try:
+            locale.setlocale(locale.LC_NUMERIC, 'pt_BR.UTF-8')
+            plt.rcParams['axes.formatter.use_locale'] = True
+        except:
+            locale.setlocale(locale.LC_NUMERIC, 'C')
+            plt.rcParams['axes.formatter.use_locale'] = False
+            print("Plotting error using ',', then was used '.' as decimal separator")
     elif decimalSep =='.':
         locale.setlocale(locale.LC_NUMERIC, 'C')
         plt.rcParams['axes.formatter.use_locale'] = False
@@ -578,8 +593,13 @@ def bars(analyses, xLabel, yLabel, yLim, xLim, title, decimalSep, barWidth,
         alpha=.60
 
     if decimalSep == ',':
-        locale.setlocale(locale.LC_NUMERIC, 'pt_BR.UTF-8')
-        plt.rcParams['axes.formatter.use_locale'] = True
+        try:
+            locale.setlocale(locale.LC_NUMERIC, 'pt_BR.UTF-8')
+            plt.rcParams['axes.formatter.use_locale'] = True
+        except:
+            locale.setlocale(locale.LC_NUMERIC, 'C')
+            plt.rcParams['axes.formatter.use_locale'] = False
+            print("Plotting error using ',', then was used '.' as decimal separator")
     elif decimalSep =='.':
         locale.setlocale(locale.LC_NUMERIC, 'C')
         plt.rcParams['axes.formatter.use_locale'] = False

--- a/pytta/_plot.py
+++ b/pytta/_plot.py
@@ -82,7 +82,7 @@ def time(sigObjs, xLabel, yLabel, yLim, xLim, title, decimalSep, timeUnit):
         except:
             locale.setlocale(locale.LC_NUMERIC, 'C')
             plt.rcParams['axes.formatter.use_locale'] = False
-            print("Plotting error using ',', then was used '.' as decimal separator")
+            ValueError("Plotting error using ',', then was used '.' as decimal separator")
     elif decimalSep =='.':
         locale.setlocale(locale.LC_NUMERIC, 'C')
         plt.rcParams['axes.formatter.use_locale'] = False


### PR DESCRIPTION
I identified an error in the plot methods, using ',' as the decimal separator (which is the default), on google colab. To pass the error I added an exception that plots using '.' as the decimal separator.