### PR TITLE
Fix SignalObj.ifft

### DIFF
--- a/pytta/_plot.py
+++ b/pytta/_plot.py
@@ -264,7 +264,8 @@ def time_dB(sigObjs, xLabel, yLabel, yLim, xLim, title, decimalSep, timeUnit):
 
     curveData = _curve_data_extractor_time_dB(sigObjs)
     for data in curveData:
-        dBSignal = 20*np.log10(np.abs(data['y']/np.sqrt(2))/data['dBRef'])
+        with np.errstate(divide='ignore'):
+            dBSignal = 20*np.log10(np.abs(data['y']/np.sqrt(2))/data['dBRef'])
         ax.plot(timeScale*data['x'], dBSignal, label=data['label'])
         yLimData = cp.copy(dBSignal)
         yLimData[np.isinf(yLimData)] = 0
@@ -412,7 +413,8 @@ def freq(sigObjs, smooth, xLabel, yLabel, yLim, xLim, title, decimalSep):
 
     curveData = _curve_data_extractor_freq(sigObjs)
     for data in curveData:
-        dBSignal = 20*np.log10(np.abs(data['y'])/data['dBRef'])
+        with np.errstate(divide='ignore'):
+            dBSignal = 20*np.log10(np.abs(data['y'])/data['dBRef'])
 
         if smooth:
             dBSignal = ss.savgol_filter(dBSignal, 31, 3)

--- a/pytta/classes/_base.py
+++ b/pytta/classes/_base.py
@@ -121,11 +121,12 @@ class PyTTaObj(RICI):
     @property
     def numSamples(self):
         return self._numSamples
-
-    @numSamples.setter
-    def numSamples(self, newNumSamples):
-        self._numSamples = newNumSamples
-        return
+    
+    # The number of samples depends on the time signal length
+    # @numSamples.setter
+    # def numSamples(self, newNumSamples):
+    #     self._numSamples = newNumSamples
+    #     return
 
     @property
     def freqMin(self):
@@ -601,8 +602,6 @@ class ChannelsList(object):
                 raise TypeError('List initializer must be either positive ' +
                                 'int, a list of positive int or ' +
                                 'ChannelObj.')
-#        else:
-#            self._channels.append(ChannelObj(1))
         return
 
     def __repr__(self):
@@ -614,17 +613,11 @@ class ChannelsList(object):
 
     def __getitem__(self, key):
         if isinstance(key, int):
-            # for ch in self._channels:
-            #     if ch.num == key:
-            #         return ch
             try:
                 channel = [ch for ch in self._channels if ch.num == key][0]
             except IndexError:
                 raise IndexError("Channel number not included.")
         elif isinstance(key, str):
-            # for ch in self._channels:
-            #     if ch.name == key or ch.code == key:
-            #         return ch
             try:
                 channel = [ch for ch in self._channels if ch.name == key or
                            ch.code == key][0]
@@ -637,9 +630,6 @@ class ChannelsList(object):
 
     def __setitem__(self, key, item):
         if isinstance(key, int):
-            # for ch in self._channels:
-            #     if ch.num == key:
-            #         return ch
             try:
                 channel = [ch for ch in self._channels if ch.num == key][0]
                 self._channels.remove(channel)
@@ -647,9 +637,6 @@ class ChannelsList(object):
             except IndexError:
                 raise IndexError("Channel number not listed.")
         elif isinstance(key, str):
-            # for ch in self._channels:
-            #     if ch.name == key or ch.code == key:
-            #         return ch
             try:
                 channel = [ch for ch in self._channels if ch.name == key or ch.code == key][0]
                 self._channels.remove(channel)

--- a/pytta/functions.py
+++ b/pytta/functions.py
@@ -980,6 +980,7 @@ def __h5_unpack(objH5Group):
         freqMin = _h5.none_parser(objH5Group.attrs['freqMin'])
         freqMax = _h5.none_parser(objH5Group.attrs['freqMax'])
         lengthDomain = objH5Group.attrs['lengthDomain']
+        comment = objH5Group.attrs['comment']
         # SignalObj attr unpacking
         channels = eval(objH5Group.attrs['channels'])
         # Added with an if for compatibilitie issues
@@ -987,7 +988,6 @@ def __h5_unpack(objH5Group):
             signalType = _h5.attr_parser(objH5Group.attrs['signalType'])
         else:
             signalType = 'power'
-        comment = objH5Group.attrs['comment']
         # Creating and conforming SignalObj
         SigObj = SignalObj(signalArray=np.array(objH5Group['timeSignal']),
                            domain='time',


### PR DESCRIPTION
The problem: freqSignal only stores half spectrum.
Previously the time signal wasn't being correctly recalculated from the half spectrum, now it's calculated based on numSamples.
Added numSamples as optional input argument when signalArray's domain is 'freq'. If not provided, numSamples will be calculated as an even number according to np.fft.rfft and np.fft.irfft.
SignalObj.freqVector is now obtained through np.fft.rfftfreq.
When freqSignal is reassigned now checking if numSamples still make sense according to the half spectrum length, otherwise freqSignal is a different signal, for which numSamples will be calculated as an even number.