### PR TITLE
Fix 'data_files' syntax in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ Authors:
 """
 
 from setuptools import setup
+from glob import glob
 
 with open("README.md", "r") as f:
     long_description = f.read()
@@ -28,7 +29,7 @@ settings = {
     'install_requires': ['numpy', 'scipy', 'matplotlib',
         'sounddevice', 'soundfile', 'h5py', 'numba'],
     'packages': ['pytta', 'pytta.classes', 'pytta.apps', 'pytta.utils'],
-    'data_files': [('examples', ['examples/*.py'])],
+    'data_files':  [('examples', glob('examples/*'))],
     # 'package_dir': {'classes': 'pytta'},
     'classifiers': [
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Currently "Build and publish PyTTa distribution package to PyPI" workflow is not working because of the changes made in setup.py. This pull request should fix this.