### PR TITLE
Fix setup.py so PyTTa is installed only with Python compatible versions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,5 @@ dmypy.json
 # DS
 .DS_Store
 
+# asdf version manager
+.tool-versions

--- a/setup.py
+++ b/setup.py
@@ -29,13 +29,16 @@ settings = {
     'install_requires': ['numpy', 'scipy', 'matplotlib',
         'sounddevice', 'soundfile', 'h5py', 'numba'],
     'packages': ['pytta', 'pytta.classes', 'pytta.apps', 'pytta.utils'],
-    'data_files':  [('examples', glob('examples/*'))],
     # 'package_dir': {'classes': 'pytta'},
+    # 'package_data': {'pytta': ['examples/*.py', 'examples/RIS/*.mat']}
+    'data_files': [('examples', glob('examples/*'))],
     'classifiers': [
-        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent", ],
-    # 'package_data': {'pytta': ['examples/*.py', 'examples/RIS/*.mat']}
+    'python_requires': '>=3.6, <3.9',
 }
 
 setup(**settings)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("README.md", "r") as f:
 
 settings = {
     'name': 'PyTTa',
-    'version': '0.1.0',
+    'version': '0.1.1',
     'description': 'Signal processing tools for acoustics and vibrations in ' +
         'python, development package.',
     'long_description': long_description,


### PR DESCRIPTION
PyTTa doesn't work with Python 3.9.0 because Numba dependecy won't install in this version as stated in https://github.com/numba/numba/issues/6345#issuecomment-738696458. I've changed setup.py so PyTTa is only installed with Python supported versions (3.6 up to 3.8).

I've also changed PyTTa version from 0.1.0 to 0.1.1 because this qualifies as a patch. A new release would be appropriated.