### PR TITLE
Bugfix concerning DC-component of Signal

### DIFF
--- a/pytta/classes/signal.py
+++ b/pytta/classes/signal.py
@@ -1117,7 +1117,8 @@ class SignalObj(_base.PyTTaObj):
         newFreqSignal = _make_rms_spectra(newFreqSignal)
         # spectrum normalization
         if self.signalType == 'power':
-            newFreqSignal /= len(newFreqSignal)
+            newFreqSignal[1:, :] /= len(newFreqSignal)  # /= numSamples/2
+            newFreqSignal[0, :] /= self.numSamples
         # assign new freq signal
         self._freqSignal = newFreqSignal
         # frequency vector (x axis)
@@ -1628,8 +1629,8 @@ class ImpulsiveResponse(_base.PyTTaObj):
 
 def _make_rms_spectra(freqSignal):
     newFreqSignal = np.zeros(freqSignal.shape, dtype=np.complex_)
-    newFreqSignal[:,:] = freqSignal / 2**(1/2)
-    newFreqSignal[0,:] = freqSignal[0,:] * 2**(1/2)
+    newFreqSignal[1:, :] = freqSignal[1:, :] / 2**(1/2)
+    newFreqSignal[0, :] = freqSignal[0, :]
     return newFreqSignal
 
 

--- a/pytta/classes/signal.py
+++ b/pytta/classes/signal.py
@@ -1132,8 +1132,13 @@ class SignalObj(_base.PyTTaObj):
         """
         # spectrum denormalization
         if self.signalType == 'power':
-            adjustedFreqSignal = \
-                self._freqSignal*len(self._freqSignal)
+            adjustedFreqSignal = np.zeros(self._freqSignal.shape, dtype=np.complex_)
+            # * N/2 for AC
+            adjustedFreqSignal[1:, :] = \
+                self._freqSignal * len(self._freqSignal)
+            # * N for DC
+            adjustedFreqSignal[0, :] = \
+                self._freqSignal[0, :] * self.numSamples
         else:
             adjustedFreqSignal = self._freqSignal
         # turning RMS amplitude into peak amplitude except DC freq
@@ -1636,7 +1641,7 @@ def _make_rms_spectra(freqSignal):
 
 def _make_pk_spectra(freqSignal):
     newFreqSignal = np.zeros(freqSignal.shape, dtype=np.complex_)
-    newFreqSignal[:,:] = freqSignal * 2**(1/2)
-    newFreqSignal[0,:] = freqSignal[0,:] / 2**(1/2)
+    newFreqSignal[1:, :] = freqSignal[1:, :] * 2**(1/2)
+    newFreqSignal[0, :] = freqSignal[0, :]
     return newFreqSignal
 


### PR DESCRIPTION
I noticed, the DC component (_freqSignal[0]) of the fft'd and rms'd signal is not being calculated correctly.

Right now, the DC value of a power signal is normalized like this:
_freqSignal[0] = rfft[0]/N * 2 * 2**(1/2)

Where IMO it should be simply 
_freqSignal[0] = rfft[0]/N

(This tutorial seems quite straight forward: https://appliedacousticschalmers.github.io/scaling-of-the-dft/AES2020_eBrief/)

I would apply these changes accordingly to SignalObj._fft() and _make_rms_spectra as seen in my upload.

For the inverse fft method, I'd insert the denormalization to fit the normalization.

To me it is also quite confusing that in SignalObj._fft(), the normalization is being done by dividing by len(newFreqSignal) (so numSamples/2) instead of self.numSamples. 
This, of course is up to interpretation though.

Cheers and thanks to everyone for the good work! Sorry if I did something the wrong way, it's my first time contributing to a GitHub repo.