### PR TITLE
python 3.11 compatibility, some plot updates, and deconv with zero pa…

### DIFF
--- a/pytta/_h5utils.py
+++ b/pytta/_h5utils.py
@@ -31,14 +31,14 @@ def int_parser(attr):
     if isinstance(attr, (np.int16,
                          np.int32,
                          np.int64,
-                         np.int,
+                         int,
                          np.int0)):
         return int(attr)
     else:
         return attr
 
 def float_parser(attr):
-    if isinstance(attr, (np.float,
+    if isinstance(attr, (float,
                         np.float16,
                         np.float32,
                         np.float64)):

--- a/pytta/_plot.py
+++ b/pytta/_plot.py
@@ -394,7 +394,7 @@ def freq(sigObjs, smooth, xLabel, yLabel, yLim, xLim, title, decimalSep):
     if xLabel is None:
         xLabel = 'Frequency [Hz]'
     if yLabel is None:
-        yLabel = 'Magnitude'
+        yLabel = 'Magnitude [dB]'
     if title is None:
         title = ''
 
@@ -426,10 +426,6 @@ def freq(sigObjs, smooth, xLabel, yLabel, yLim, xLim, title, decimalSep):
     ax.set_ylabel(yLabel, fontsize=16)
     ax.legend(loc='best', fontsize=12)
 
-    if xLim is None:
-        xLim = [data['minFreq'], data['maxFreq']]
-    ax.set_xlim(xLim)
-
     if yLim is None:
         yLim = [np.nanmin(yLims[:,0]), np.nanmax(yLims[:,1])]
         margin = (yLim[1] - yLim[0]) / 20
@@ -443,6 +439,13 @@ def freq(sigObjs, smooth, xLabel, yLabel, yLim, xLim, title, decimalSep):
     ax.xaxis.set_major_formatter(ticker.ScalarFormatter(useOffset=True))
     for item in (ax.get_xticklabels() + ax.get_yticklabels()):
         item.set_fontsize(14)
+    freq_oct_list = [16, 31.5, 63, 125, 250, 500, 1000, 2000, 4000, 8000, 16000]
+    freq_oct_list_str = [str(item) for item in freq_oct_list]
+    ax.set_xticks(freq_oct_list)
+    ax.set_xticklabels(freq_oct_list_str)
+    if xLim is None:
+        xLim = [data['minFreq'], data['maxFreq']]
+    ax.set_xlim(xLim)
 
     return fig
 

--- a/pytta/generate.py
+++ b/pytta/generate.py
@@ -266,8 +266,8 @@ def __do_sweep_windowing(inputSweep,
     # exact sample where the chirp reaches freqMax [Hz]
     freqMaxSample = np.where(freqSweep <= freqMax)
     freqMaxSample = len(freqSweep) - freqMaxSample[-1][-1]
-    windowStart = ss.hanning(2*freqMinSample)
-    windowEnd = ss.hanning(2*freqMaxSample)
+    windowStart = ss.hann(2*freqMinSample)
+    windowEnd = ss.hann(2*freqMaxSample)
 
     # Uses first half of windowStart, last half of windowEnd, and a vector of
     # ones with the remaining length, in between the half windows
@@ -459,7 +459,7 @@ def __do_noise_windowing(inputNoise,
                          window):
     # sample equivalent to the first five percent of noise duration
     fivePercentSample = int((5/100) * (noiseSamples))
-    windowStart = ss.hanning(2*fivePercentSample)
+    windowStart = ss.hann(2*fivePercentSample)
     fullWindow = np.concatenate((windowStart[0:fivePercentSample],
                                  np.ones(int(noiseSamples-fivePercentSample))))
     newNoise = (fullWindow * inputNoise.T).T


### PR DESCRIPTION
I made some updates. Major things in this commit are:

- some python 3.11 compatibilities: example "scipy.signal.hann" is not suported anymore - changed to scipy.signal.hanning
- I included minor stuff on plot_freq() method
- in the "ImpulsiveResponse" class I included a "linear_zp" method - allowing to zero padd input and output before performing spectral division.